### PR TITLE
Remove unnecessary filter, actually print inline style

### DIFF
--- a/svg-social-menu.php
+++ b/svg-social-menu.php
@@ -65,9 +65,3 @@ function svg_social_menu_register_widget() {
 }
 
 add_action( 'widgets_init', 'svg_social_menu_register_widget' );
-
-function svg_social_menu_inline_style_change( $styles ) {
-	$styles = '';
-}
-
-add_filter( 'svg_social_menu_inline_style', 'svg_social_menu_inline_style_change' );


### PR DESCRIPTION
The filter you had setup down the bottom (presumably for an example or testing) has two issues

1- doesn't return a value
2 - blows away all the previous inline styles

Could be great to include in a snippet - just link to the gist from the plugin page, but seriously this messed up pretty much everything for a plug and play experience, and really should have been caught before submission to the repo.